### PR TITLE
Fix bug with AES::key ignoring the length param

### DIFF
--- a/lib/aes/aes.rb
+++ b/lib/aes/aes.rb
@@ -84,7 +84,7 @@ module AES
   
     # Generate a random key
     def random_key(length=256)
-      _random_seed.unpack('H*')[0][0..((length/8)-1)]
+      _random_seed(length/8).unpack('H*')[0]
     end
   
     private


### PR DESCRIPTION
It seems the last commit with this description did not really fix the issue. A 256 bit key could not be generated, but with this change it can.
