### PR TITLE
Fix key validation bug

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,0 +1,5 @@
+2017-01-12
+
+* No longer accept keys that are not in hex string format
+* No longer accept keys that are not of the correct length (64 characters hex == 256 bits raw binary)
+* Generated keys use only secure random from OpenSSL::Random. If OpenSSL::Random is not defined, AES will no longer work (whereas it used to use an insecure key generating method)

--- a/README.rdoc
+++ b/README.rdoc
@@ -8,30 +8,29 @@ Usage:
 
  # Generate a random key
  key = AES.key
-  => "290c3c5d812a4ba7ce33adf09598a462"
-  
+  => "3a45d76fa5f0bd21f8dfd3f4e98fc4effe59e503857618cf58a11a31a276177b"
+
  # Encrypt a string.  Default output is base_64 encoded, init_vector and cipher_text are joined with "$"
  b64 = AES.encrypt("A super secret message", key)
-  => "IJjbgbv/OvPIAf4R5qAWyg==$fy0v7JwRX4kyAWflgouQlt9XGmiDKvbQMRHmQ+vy1fA="
+  => "IuTX8xX2XrrTVsq6SwWtFw==$+A8IiuUgPE+nRFVinA0vd5LUInd3QM3rGViNJIq3mx4="
 
  # Same as above but minus the base64 encoding, init_vector and cipher_text are shoved into an array
  plain = AES.encrypt("A super secret message", key, {:format => :plain}) #
-  => [";\202\222\306\376<\206\343\023\245\312\225\214KAm", 
-      "C\343\023\323U~W>\023y\217\341\201\371\352\334\311^\307\352{\020 H(DVw\3224N\223"]
+  => ["xF.^\x80ML'6\x10F2Z\xF8\x9Ep", "r\xA8P\xEBP\x10_\xC1\xD3B\xC3\xAB\xB3_qy\x91Q\x8C~\x1Ec\x9FD'\x8D\xB8\xBF\xB0\xA6\a\x9A"]
 
  # Generate a random initialization vector
  iv = AES.iv(:base_64)
-  => "IJjbgbv/OvPIAf4R5qAWyg=="
- 
- # Encrypt a string, with a provided key and init_vector.  
+  => "G8iY1e3Yvf6OqFAD4w2ZVw=="
+
+ # Encrypt a string, with a provided key and init_vector.
  b64_iv = AES.encrypt("A super secret message", key, {:iv => iv})
-  => "IJjbgbv/OvPIAf4R5qAWyg==$fy0v7JwRX4kyAWflgouQlt9XGmiDKvbQMRHmQ+vy1fA="
- 
+  => "G8iY1e3Yvf6OqFAD4w2ZVw==$B68lzBMXyOLXBSbPg4BgLBQRf68xVmS2oK4r2Xb+tXc="
+
  AES.decrypt(b64, key)
   => "A super secret message"
- 
+
  AES.decrypt(plain, key, {:format => :plain})
-  => "A super secret message" 
+  => "A super secret message"
 
  # By default data is padded to the nearest 16 bytes block.  To turn
  # this off, you may use the :padding => false (or nil) option.
@@ -40,7 +39,7 @@ Usage:
  # the following example the message is exactly 16 bytes long, so no
  # error aries.
  msg = AES.encrypt("A secret message", key, {:padding => false})
-  => "SnD+WIfEfjZRrl+WAM/9pw==$89sGGZsu973j8Gl6aXC8Uw=="
+  => "3orl0zsORP06B8+eyM+XsQ==$bqsvFPjTOzccKA/N3IEnug=="
 
  # Be sure to pass the same padding option when decrypting the
  # message, as it will fail if you try to decrypt unpadded data and

--- a/aes.gemspec
+++ b/aes.gemspec
@@ -21,6 +21,7 @@ Gem::Specification.new do |s|
     "Gemfile",
     "LICENSE.txt",
     "README.rdoc",
+    "CHANGELOG",
     "Rakefile",
     "VERSION",
     "aes.gemspec",

--- a/lib/aes/aes.rb
+++ b/lib/aes/aes.rb
@@ -50,6 +50,9 @@ module AES
       merge_options opts
       @cipher = nil
       @key    = key
+      unless @key =~ /\A[A-F0-9]{64}\z/i
+        raise ArgumentError, "AES Key must be a 64 character hex string"
+      end
       @iv   ||= ::AES.iv
       self
     end

--- a/test/test_aes.rb
+++ b/test/test_aes.rb
@@ -1,9 +1,10 @@
 require 'helper'
 
 class TestAES < Test::Unit::TestCase
-    
+  test_key = "66c2454a167226f132098cfeb18eac31ec2a66104fc3c2187816baaba2d8ed39"
+
   should "encrypt and decrypt a string" do
-    key = "01234567890123456789012345678901"
+    key = test_key
     msg = "This is a message that nobody should ever see"
     enc = AES.encrypt(msg, key)
     assert_equal msg, AES.decrypt(enc, key)
@@ -12,7 +13,7 @@ class TestAES < Test::Unit::TestCase
   end
   
   should "produce the same encrypted string when provided an identical key and iv" do
-    key  = "01234567890123456789012345678901"
+    key = test_key
     msg  = "This is a message that nobody should ever see"
     iv   = AES.iv(:base_64)
     enc1 = AES.encrypt(msg, key, {:iv => iv})
@@ -21,7 +22,7 @@ class TestAES < Test::Unit::TestCase
   end
     
   should "handle padding option" do
-    key = "01234567890123456789012345678901"
+    key = test_key
     msg = "This is a message that nobody should ever see"
     # unpadded message length should be a multiple of cipher block
     # length (16 bytes)
@@ -32,8 +33,18 @@ class TestAES < Test::Unit::TestCase
   end
   
   should "generate a new key when AES#key" do
-    assert_equal 32, AES.key.length
-    assert_equal 44, AES.key(256, :base_64).length
+    assert_equal 64, AES.key.length
+    assert_equal 89, AES.key(256, :base_64).length
+  end
+
+  should "not accept a non-hex key" do
+    key = "NotHexEvenThoughItsSixtyFourCharactersLongSoAnErrorIsExpectedNow"
+    msg = "This is the plaintext message"
+
+    assert_raise ArgumentError do
+      enc = AES.encrypt(msg, key)
+    end
+
   end
     
 end


### PR DESCRIPTION
Fixes #5 

* No longer accept keys that are not in hex string format
* No longer accept keys that are not of the correct length (64 characters hex == 256 bits raw binary)
* Generate keys of the correct length
* Generated keys use only secure random from OpenSSL::Random. If OpenSSL::Random is not defined, AES will no longer work (whereas it used to use an insecure key generating method)