### PR TITLE
Removed deprecation warning „constant OpenSSL::Cipher::Cipher is deprecated“

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,7 @@ source "http://rubygems.org"
 # Add dependencies to develop your gem here.
 # Include everything needed to run rake, tests, features, etc.
 group :development do
+  gem "test-unit"
   gem "shoulda"
   gem "bundler" 
   gem "jeweler" 

--- a/lib/aes/aes.rb
+++ b/lib/aes/aes.rb
@@ -148,7 +148,7 @@ module AES
       
       # Create a new cipher using the cipher type specified
       def _setup(action)
-        @cipher ||= OpenSSL::Cipher::Cipher.new(@options[:cipher]) 
+        @cipher ||= OpenSSL::Cipher.new(@options[:cipher]) 
         # Toggles encryption mode
         @cipher.send(action)
         @cipher.padding = @options[:padding]


### PR DESCRIPTION
Tests pass without deprecation warning in Ruby 2.4.0.

The gem "test-unit" had to be added additionally to make tests run.