### PR TITLE
Fix break AES-128-CBC on Ruby 2.5.3. Change hard code 32 key len by cipher key len returned by OpenSSL. 

### DIFF
--- a/lib/aes/aes.rb
+++ b/lib/aes/aes.rb
@@ -152,7 +152,7 @@ module AES
         # Toggles encryption mode
         @cipher.send(action)
         @cipher.padding = @options[:padding]
-        @cipher.key = @key.unpack('a2'*32).map{|x| x.hex}.pack('c'*32)
+        @cipher.key = @key.unpack('a2'*@cipher.key_len).map{|x| x.hex}.pack('c'*@cipher.key_len)
       end
   end
 end


### PR DESCRIPTION
Regarding to the issue https://github.com/chicks/aes/issues/17
Error in Ruby 2.5.3, set cipher.key: Exception “key must be 16 bytes"
OpenSSL::Cipher.new('AES-128-CBC') only accept key with length is 16 bytes.

While in the code, it return 32-byte-key with totally 16 trailing zero bytes:
`@key.unpack('a2'*32).map{|x| x.hex}.pack('c'*32) => "o\xA8\xBB\a#'\xF8\xD0\xE4\v\x85\xFA\xD9\x05\x10\xF9\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00"`

